### PR TITLE
Fix cursed commit causing processing errors

### DIFF
--- a/process/src/ChangeLogCommit.js
+++ b/process/src/ChangeLogCommit.js
@@ -25,6 +25,12 @@ class ChangeLogCommit {
       return false;
     if (this.message.startsWith("Merge branch"))
       return false;
+    
+    // Broken commit causing errors. An object was removed before all references to it was.
+    // https://github.com/twohoursonelife/OneLifeData7/commit/8833527cbbb2d5d3d65f174a7d412cfa7fe5cbbe
+    if (this.message.startsWith("Merchant test redo"))
+      return false;
+    
     return true
   }
 


### PR DESCRIPTION
This should resolve issues related to object 8316 being missing.
At some point in 2021 we removed this object from the Data repo before it was removed from a transition reference, Twotech doesn't like that.

I tested this over and over but there were times it was inconsistent.

If issue persists an additional option would be to patch Git.js line 33 with something like:
```javascript
  fileContent(sha, path) {
    if (path == "objects/8316.txt") {
      path = "objects/8317.txt";
    }
    return this.run("show", `${sha}:${path}`);
  }
```