### PR TITLE
Fix that displayed object images may show invalid image while loading.

### DIFF
--- a/src/components/ObjectImage.vue
+++ b/src/components/ObjectImage.vue
@@ -15,7 +15,7 @@
     <div v-if="move" class="move">move</div>
     <div v-if="ground" class="ground"></div>
     <div v-if="object && !legacy" class="image">
-      <img :id="imageID" :src="imageUrl" :alt="title" />
+      <img :key="imageID" :src="imageUrl" :alt="title" />
     </div>
   </ObjectImageWrapper>
 </template>


### PR DESCRIPTION
This was a noticeable and an old issue where object images will become out of sync with their respective object name in the search dropdown while you search. this is very noticeable on slow internet but can happen to even if you have a fast internet connection.
This is a comparison for before and after this change:


Before:
https://github.com/twohoursonelife/twotech/assets/37766821/585c761e-1f21-404a-bf22-c010dd2be610

After:
https://github.com/twohoursonelife/twotech/assets/37766821/119ec001-c477-4a3b-9b26-d2e39f69fa12


