### PR TITLE
Dockerized data processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules/
 npm-debug.log
 yarn-error.log
 public.zip
+/process-docker
 
 # Editor directories and files
 .idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-FROM node:lts-bookworm AS process
-# ready to update to Node 18
+FROM node:18-bookworm AS process
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -36,7 +35,7 @@ ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["/bin/bash"]
 
 
-FROM node:14-alpine AS build
+FROM node:18-alpine AS build
 
 WORKDIR /usr/local/twotech
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:14-buster-slim AS process # ready to update to Node 18
+FROM node:lts-bookworm AS process
+# ready to update to Node 18
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -8,6 +9,7 @@ RUN apt-get update && apt-get install \
     --yes --no-install-recommends \
     build-essential \
     git \
+    gosu \
     g++ \
     imagemagick \
     libcairo2-dev \
@@ -15,19 +17,23 @@ RUN apt-get update && apt-get install \
     libpango1.0-dev \
     libgif-dev \
     libsox-fmt-mp3 \
-    sox && \
-    rm -rf /var/lib/apt/lists/
+    sox \
+    && rm -rf /var/lib/apt/lists/
 
 COPY process/package*.json process/
-
-RUN cd process && \
-    npm clean-install
 
 COPY process/ process/
 COPY public/ public/
 
 #RUN node process download
 
+
+FROM process AS build_env
+
+WORKDIR /usr/local/twotech
+COPY patch /
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["/bin/bash"]
 
 
 FROM node:14-alpine AS build

--- a/README.md
+++ b/README.md
@@ -64,6 +64,33 @@ node process sounds
 node process
 ```
 
+### Processing Script (Docker version)
+
+Note 1: This is for a Linux machine with Docker installed.
+
+Note 2: This creates a separate process directory, to not mess with the main build.
+
+To only generate the twotech processed data used for the website, first run:
+```
+./prepare-process-docker.sh
+```
+
+This will build the Docker image used for the build environment, and then set up the process directory for use.
+
+You can then run different build commands within a container of this image:
+```
+./docker-run.sh node process-docker
+```
+```
+./docker-run.sh node process-docker download
+```
+```
+./docker-run.sh node process-docker sprites
+```
+```
+./docker-run.sh node process-docker sounds
+```
+
 ### Modded Support
 
 _Following forking this project, the following is less supported and we do not make use of this ourselves._

--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ For detailed explanation on how things work, consult the [docs for vue-loader](h
 
 The script is under the folder `process`. It will pull the latest data from the game data repository (if provided `download` as a command line argument), and then generate JSON files for the objects. It will also composite the sprites and create PNGs for each object in the game.
 
-To get it running, you will need to install [ImageMagick](https://www.imagemagick.org/script/index.php), [Canvas dependencies](https://github.com/Automattic/node-canvas/blob/v1.x/Readme.md#installation), and [SoX](http://sox.sourceforge.net) and then:
+To get it running, you will need to install [ImageMagick](https://www.imagemagick.org/script/index.php), [Canvas dependencies](https://github.com/Automattic/node-canvas/blob/v1.x/Readme.md#installation), and [SoX](http://sox.sourceforge.net).
+
+A useful list of dependency packages can be found in the `Dockerfile`. It's not clear if the Dockerfile can actually be used as it is, but it gives a good list of `apt` dependencies to grab.
 
 ``` bash
 cd process

--- a/README.md
+++ b/README.md
@@ -41,7 +41,11 @@ The script is under the folder `process`. It will pull the latest data from the 
 
 To get it running, you will need to install [ImageMagick](https://www.imagemagick.org/script/index.php), [Canvas dependencies](https://github.com/Automattic/node-canvas/blob/v1.x/Readme.md#installation), and [SoX](http://sox.sourceforge.net).
 
-A useful list of dependency packages can be found in the `Dockerfile`. It's not clear if the Dockerfile can actually be used as it is, but it gives a good list of `apt` dependencies to grab.
+```
+sudo apt-get install imagemagick libcairo2-dev libjpeg-dev libpango1.0-dev libgif-dev build-essential g++ libsox-fmt-mp3 sox
+```
+
+See [SERVER.md](/SERVER.md) for a thorough deployment setup guide.
 
 ``` bash
 cd process
@@ -66,9 +70,9 @@ node process
 
 ### Processing Script (Docker version)
 
-Note 1: This is for a Linux machine with Docker installed.
+> Note 1: This is for a Linux machine with Docker installed.
 
-Note 2: This creates a separate process directory, to not mess with the main build.
+> Note 2: This creates a separate process directory, to not mess with the main build.
 
 To only generate the twotech processed data used for the website, first run:
 ```

--- a/docker-build_env.sh
+++ b/docker-build_env.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+docker build --no-cache --target build_env --tag twotech-build_env:latest "${SCRIPT_DIR}"

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Usage: run-docker [cmd [arg0 [arg1 ...]]]
+#
+# Maps ~/.ssh and ~/.npm in the Docker container
+# ~/.ssh is simply passed through, so the build can use the user's SSH credentials when needed.
+# ~/.npm is mapped to a temporary directory, deleted at the end of the script, to keep usage isolated and clean.
+# Note that npm stores its cache in the .npm directory, so it could perhaps be made
+# durable and save a bit of build time, but the time difference is small.
+
+image="${IMAGE:-"twotech-build_env"}"
+tag="${TAG:-"latest"}"
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+if [[ "$(docker images -q "${image}":"${tag}" 2> /dev/null)" == "" ]]; then
+	echo "Docker image $image:$tag does not exist. Running script to create it."
+	# if [[ $? -ne 0 ]]; then
+	if ! "${SCRIPT_DIR}"/docker-build_env.sh; then
+		echo "Could not create Docker image! Exiting..."
+		exit 1
+	fi
+fi
+
+echo "Sharing directory $SCRIPT_DIR"
+
+# Make temporary storage for ~/.npm, since earlier versions of npm store
+# stuff in ~/.npm and can't be persuaded otherwise. Clean up when done.
+
+BUILD_TMP=""
+
+function cleanup() {
+	echo "Cleaning up"
+	if [ -n "$BUILD_TMP" ]; then
+		rm -rf "$BUILD_TMP"
+	fi
+}
+
+function trapcmd() {
+	trapStatus=$?
+	if [ $trapStatus -eq 0 ]; then
+		trapStatus=1
+	fi
+	cleanup
+	exit $trapStatus
+}
+
+trap "trapcmd" HUP TERM INT QUIT TRAP ABRT SEGV
+
+if [ -z "$TMPDIR" ]; then
+	TMPDIR=/tmp
+fi
+BUILD_TMP="$(mktemp -d "$TMPDIR/twotech_build.XXXX")"
+echo "Putting temp files in $BUILD_TMP"
+BUILD_TMP_NPM="$BUILD_TMP/.npm"
+mkdir -p "$BUILD_TMP_NPM"
+
+docker run -it --rm \
+	--env LINUX_USER="$(id -un)" \
+	--env LINUX_UID="$(id -u)" \
+	--env LINUX_GROUP="$(id -gn)" \
+	--env LINUX_GID="$(id -g)" \
+	--env LINUX_DIR="$PWD" \
+	--env TERM="$TERM" \
+	--mount "src=$SCRIPT_DIR,target=$SCRIPT_DIR,type=bind" \
+	--mount "src=${HOME}/.ssh,target=${HOME}/.ssh,type=bind" \
+	--mount "src=${BUILD_TMP_NPM},target=${HOME}/.npm,type=bind" \
+	"$image:$tag" "$@"
+
+cleanup

--- a/patch/docker-entrypoint.sh
+++ b/patch/docker-entrypoint.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+# Usage: docker-entrypoint.sh [cmd [arg0 [arg1 ...]]]
+
+echo ">>>>> Entering twotech development container... <<<<<"
+# Exit on failure
+set -e
+# Pull Docker ENV variables, using defaults if not set
+user="${LINUX_USER:-"user"}"
+uid="${LINUX_UID:-"1000"}"
+group="${LINUX_GROUP:-"dev"}"
+gid="${LINUX_GID:-"1000"}"
+dir="${LINUX_DIR:-"/home/$user"}"
+#
+echo "Configuring container for user:$user($uid) group:$group($gid)..."
+
+# Check if a user with the given UID already exists
+if id -u "$uid" >/dev/null 2>&1; then
+    # If the user exists, modify the user and group
+    usermod -l "$user" "$(id -un "$uid")"
+    groupmod -n "$group" "$(id -gn "$uid")"
+else
+    # If the user does not exist, create the user and group
+    groupadd -f -g "$gid" "$group"
+    useradd -u "$uid" -g "$gid" -m "$user"
+fi
+
+# Start here
+cd "$dir"
+# Run cmd as new user
+gosu "$user" "$@"
+#
+echo ">>>>> Leaving twotech development container... <<<<<"

--- a/prepare-process-docker.sh
+++ b/prepare-process-docker.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+mkdir -p ./process-docker
+rsync -a --exclude 'node_modules' ./process/ ./process-docker/ \
+&& cd ./process-docker \
+&& ../docker-run.sh npm i \
+&& ../docker-run.sh npm clean-install


### PR DESCRIPTION
* Dockerfile partially fixed.
  * Process stage now has necessary prerequisites.
  * Added build_env stage, which is used to do work on repository using build_env container.
* Added `prepare-process-docker.sh` script, which creates a copy of the process directory at process-docker, and does the npm install and npm clean-install steps.
* Added `docker-run.sh` script, which can be used to execute commands in a build_env container.
  * The build_env image has `docker-entrypoint.sh`, which, together with `docker-run.sh`, will expose minimal parts of the host OS to the build_env image so it can do work in as isolated an environment as possible
  * Added info to README on how to use these new tools.