### PR TITLE
Add name for moveType 8 (tentatively set as "AdjacentInteraction")

### DIFF
--- a/src/components/ObjectInspector.vue
+++ b/src/components/ObjectInspector.vue
@@ -178,7 +178,7 @@ export default {
     },
     moveType() {
       if (!this.object.data.moveType) return;
-      const types = ["None", "Chase", "Flee", "Random", "North", "South", "East", "West", "AdjacentInteraction"];
+      const types = ["None", "Chase", "Flee", "Random", "North", "South", "East", "West", "Find"];
       return types[this.object.data.moveType];
     },
     numUses() {

--- a/src/components/ObjectInspector.vue
+++ b/src/components/ObjectInspector.vue
@@ -178,7 +178,7 @@ export default {
     },
     moveType() {
       if (!this.object.data.moveType) return;
-      const types = ["None", "Chase", "Flee", "Random", "North", "South", "East", "West"];
+      const types = ["None", "Chase", "Flee", "Random", "North", "South", "East", "West", "AdjacentInteraction"];
       return types[this.object.data.moveType];
     },
     numUses() {


### PR DESCRIPTION
When doing my own parsing of the game code and of the twotech data, I noticed that twotech's code was missing an entry for a movement type of "8", which is described [here in the game code](https://github.com/twohoursonelife/OneLife/blob/4b3907865bb318a40ecbc7296024f89200358057/server/map.cpp#L5327).

Essentially, the object seeks out interactable objects in the spaces adjacent to it. If no interactable objects are in those spaces, it falls back to random movement.

I came up with a strawman name for this movement type, `AdjacentInteraction`, but I am certainly open to different names. It would just be great to have these objects get their movement types on their twotech pages!