### PR TITLE
Add subfilters to Clothing and Containers filters.

### DIFF
--- a/process/src/ObjectFilters.js
+++ b/process/src/ObjectFilters.js
@@ -1,79 +1,213 @@
 "use strict";
 
+// Clothing and its sub-filters
+
+const Clothing_Head = {
+  key: "head",
+  name: "Head",
+  path: "",
+  subfilters: {},
+  filter_single(object) {
+    return object.isClothing() && object.data.clothing == "h";
+  }
+}
+
+const Clothing_Top = {
+  key: "top",
+  name: "Top",
+  path: "",
+  subfilters: {},
+  filter_single(object) {
+    return object.isClothing() && object.data.clothing == "t";
+  }
+}
+
+const Clothing_Pack = {
+  key: "pack",
+  name: "Pack",
+  path: "",
+  subfilters: {},
+  filter_single(object) {
+    return object.isClothing() && object.data.clothing == "p";
+  }
+}
+
+const Clothing_Bottom = {
+  key: "bottom",
+  name: "Bottom",
+  path: "",
+  subfilters: {},
+  filter_single(object) {
+    return object.isClothing() && object.data.clothing == "b";
+  }
+}
+
+const Clothing_Shoe = {
+  key: "shoe",
+  name: "Shoe",
+  path: "",
+  subfilters: {},
+  filter_single(object) {
+    return object.isClothing() && object.data.clothing == "s";
+  }
+}
+
 const Clothing = {
   key: "clothing",
   name: "Clothing",
-  filter(objects) {
-    return objects.filter(o => o.isClothing());
+  path: "",
+  subfilters: {
+    head: Clothing_Head,
+    top: Clothing_Top,
+    pack: Clothing_Pack,
+    bottom: Clothing_Bottom,
+    shoe: Clothing_Shoe,
+  },
+  filter_single(object) {
+    return object.isClothing();
   }
 }
 
+// Food
 const Food = {
   key: "food",
   name: "Food",
-  filter(objects) {
-    return objects.filter(o => o.data.foodValue[0] > 0);
+  path: "",
+  subfilters: {},
+  filter_single(object) {
+    return object.data.foodValue[0] > 0;
   }
 }
 
+// Tools
 const Tools = {
   key: "tools",
   name: "Tools",
-  filter(objects) {
-    return objects.filter(o => o.isTool());
+  path: "",
+  subfilters: {},
+  filter_single(object) {
+    return object.isTool();
+  }
+}
+
+// Containers and its subfilters
+const SmallContainers = {
+  key: "small",
+  name: "Small",
+  path: "",
+  subfilters: {},
+  filter_single(object) {
+    return object.isCraftableContainer() && object.data.slotSize == 1;
+  }
+}
+
+const LargeContainers = {
+  key: "large",
+  name: "Large",
+  path: "",
+  subfilters: {},
+  filter_single(object) {
+    return object.isCraftableContainer() && object.data.slotSize == 2;
+  }
+}
+
+const ExtraLargeContainers = {
+  key: "extra_large",
+  name: "Extra Large",
+  path: "",
+  subfilters: {},
+  filter_single(object) {
+    return object.isCraftableContainer() && object.data.slotSize == 3;
+  }
+}
+
+const OtherContainers = {
+  key: "other",
+  name: "Other Sizes",
+  path: "",
+  subfilters: {},
+  filter_single(object) {
+    return object.isCraftableContainer() && !(object.data.slotSize == 1 || object.data.slotSize == 2 || object.data.slotSize == 3);
   }
 }
 
 const Containers = {
   key: "containers",
   name: "Containers",
-  filter(objects) {
-    return objects.filter(o => o.isCraftableContainer());
+  path: "",
+  subfilters: {
+    "small": SmallContainers,
+    "large": LargeContainers,
+    "extra_large": ExtraLargeContainers,
+    "other": OtherContainers,
+  },
+  filter_single(object) {
+    return object.isCraftableContainer();
   }
 }
 
+// HeatSources
 const HeatSources = {
   key: "heat",
   name: "Heat Sources",
-  filter(objects) {
-    return objects.filter(o => o.data.heatValue > 0);
+  path: "",
+  subfilters: {},
+  filter_single(object) {
+    return object.data.heatValue > 0;
   }
 }
 
+// WaterSources
 const WaterSources = {
   key: "water",
   name: "Water Sources",
-  filter(objects) {
-    return objects.filter(o => o.isWaterSource());
+  path: "",
+  subfilters: {},
+  filter_single(object) {
+    return object.isWaterSource();
   }
 }
 
+// Natural
 const Natural = {
   key: "natural",
   name: "Natural",
-  filter(objects) {
-    return objects.filter(o => o.isNatural());
+  path: "",
+  subfilters: {},
+  filter_single(object) {
+    return object.isNatural();
   }
 }
 
+function setup_filters_recursively(filter, gameObjects, path) {
+  filter.path = path + `/${filter.key}`;
+  if (filter.filter_single) {
+    filter.ids = gameObjects.filter(o => filter.filter_single(o)).map(o => o.id);
+  }
+  for (let child in filter.subfilters) {
+    filter.subfilters[child] = setup_filters_recursively(filter.subfilters[child], gameObjects, filter.path);
+  }
+  return filter;
+}
+
 const ObjectFilters = {
-  filters: [
-    Clothing,
-    Food,
-    Tools,
-    Containers,
-    HeatSources,
-    Natural,
-  ],
+  filters: {
+    "clothing": Clothing,
+    "food": Food,
+    "tools": Tools,
+    "containers": Containers,
+    "heatSources": HeatSources,
+    "natural": Natural,
+  },
   jsonData(objects) {
     objects = objects.filter(o => o.canFilter());
-    return this.filters.map(f => {
-      return {
-        key: f.key,
-        name: f.name,
-        ids: f.filter(objects).map(o => o.id),
-      };
+    const modifiedFilters = {};
+    Object.entries(this.filters).forEach(([f_key, f_val]) => {
+      // For each top level filter, we need to go into each of f.subfilters (recursively), and populate their ids with their filters
+      let modifiedFilter = setup_filters_recursively(f_val, objects, "/filter");
+      modifiedFilters[f_key] = modifiedFilter;
     });
+    return modifiedFilters;
   }
 }
 

--- a/process/src/ObjectFilters.js
+++ b/process/src/ObjectFilters.js
@@ -196,7 +196,7 @@ const ObjectFilters = {
     "food": Food,
     "tools": Tools,
     "containers": Containers,
-    "heatSources": HeatSources,
+    "heat": HeatSources,
     "natural": Natural,
   },
   jsonData(objects) {

--- a/process/src/SitemapGenerator.js
+++ b/process/src/SitemapGenerator.js
@@ -15,8 +15,14 @@ class SitemapGenerator {
 
     sitemap.add({url: "/"});
 
-    for (let filter of ObjectFilters.filters) {
-      sitemap.add({url: `/filter/${filter.key}`});
+    function addFilter(filter) {
+      sitemap.add({url: filter.path});
+      Object.values(filter.subfilters).forEach((subfilter) => {
+        addFilter(subfilter);
+      });
+    }
+    for (let filter of Object.values(ObjectFilters.filters)) {
+      addFilter(filter);
     }
 
     for (let object of objects) {

--- a/src/App.vue
+++ b/src/App.vue
@@ -126,7 +126,7 @@ export default {
   routes: [
     {path: "/", component: ObjectBrowser},
     {path: "/not-found", component: NotFound},
-    {path: "/filter/:filter", component: ObjectBrowser},
+    {path: "/filter/:filter*", component: ObjectBrowser},
     {path: "/letters", component: RecipeForLetters},
     {path: "/versions", component: ChangeLog},
     {path: "/versions/:id", component: ChangeLog},

--- a/src/components/ObjectBrowser.vue
+++ b/src/components/ObjectBrowser.vue
@@ -11,6 +11,18 @@
       <BiomeList />
     </div>
 
+    <div v-if="showClothingFilters" class="filterList">
+      <div class="clothingFilter" v-for="filter in clothingFilters" >
+        <ObjectFilter :filter="filter" :selected="filter == selectedFilter" />
+      </div>
+    </div>
+
+    <div v-if="showContainerFilters" class="filterList">
+      <div class="containerFilter" v-for="filter in containerFilters" >
+        <ObjectFilter :filter="filter" :selected="filter == selectedFilter" />
+      </div>
+    </div>
+
     <div class="objectListWrapper">
       <div class="objectListHeader">
         <div class="objectListSorter">
@@ -72,9 +84,21 @@ export default {
     filters() {
       return GameObject.filters;
     },
+    clothingFilters() {
+      return GameObject.findFilter("clothing").subfilters;
+    },
+    containerFilters() {
+      return GameObject.findFilter("containers").subfilters;
+    },
     showBiomes() {
       return this.selectedFilter && this.selectedFilter.key === "natural";
     },
+    showClothingFilters() {
+      return this.selectedFilter && this.selectedFilter.path.startsWith("/filter/clothing");
+    },
+    showContainerFilters() {
+      return this.selectedFilter && this.selectedFilter.path.startsWith("/filter/containers");
+    }
   },
   methods: {
     handleScroll() {

--- a/src/components/ObjectFilter.vue
+++ b/src/components/ObjectFilter.vue
@@ -13,7 +13,7 @@ export default {
   computed: {
     url() {
       if (this.selected) return "/";
-      return `/filter/${this.filter.key}`;
+      return `${this.filter.path}`;
     }
   }
 }

--- a/src/models/GameObject.js
+++ b/src/models/GameObject.js
@@ -77,8 +77,16 @@ export default class GameObject {
     return object;
   }
 
-  static findFilter(key) {
-    return this.filters.find(f => f.key == key);
+  static findFilter(key_path) {
+    if (!key_path) {
+      return null;
+    }
+    let parts = key_path.split('/');
+    let filter = this.filters[parts.shift()];
+    for (let part of parts) (
+      filter = filter.subfilters[part]
+    )
+    return filter;
   }
 
   static addLegacyObject(attributes) {


### PR DESCRIPTION
Clicking on Clothing or Containers filters will now pop down a second set of filters. These are subfilters for that main filter type.

These filters can be anything (you could have a filter for all items as a subfilter to some filter), but for obvious reasons should likely be a subset of the main filter category.

I made subfilters for Clothing and Containers. Clothing by different types (Head, Top, Bottom, Shoe, Pack), and Containers by slot size (small, large, extra large, other).

![Screenshot 2024-08-03 021432](https://github.com/user-attachments/assets/8f3d0ec9-d9fe-43c0-a9b1-46a30653bd2a)
![Screenshot 2024-08-03 021542](https://github.com/user-attachments/assets/51f33250-c5ab-4555-a5d0-25e038dde3c1)
