### PR TITLE
Move processing code to Typescript

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,16 +56,16 @@ npm install
 cd ..
 
 # run script including downloading latest data and processing sprites
-node process download
+npm run process -- download
 
 # if you want to re-process the sprites without downloading data
-node process sprites
+npm run process -- sprites
 
 # if you want to re-process the sounds without downloading data
-node process sounds
+npm run process -- sounds
 
 # or process without generating sprites
-node process
+npm run process
 ```
 
 ### Processing Script (Docker version)
@@ -83,16 +83,16 @@ This will build the Docker image used for the build environment, and then set up
 
 You can then run different build commands within a container of this image:
 ```
-./docker-run.sh node process-docker
+./docker-run.sh npm run process
 ```
 ```
-./docker-run.sh node process-docker download
+./docker-run.sh npm run process -- download
 ```
 ```
-./docker-run.sh node process-docker sprites
+./docker-run.sh npm run process -- sprites
 ```
 ```
-./docker-run.sh node process-docker sounds
+./docker-run.sh npm run process -- sounds
 ```
 
 ### Modded Support

--- a/SERVER.md
+++ b/SERVER.md
@@ -81,7 +81,7 @@ Then run it:
 
 ```
 cd onetech
-node process download
+npm run process -- download
 ```
 
 ## Cron

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
   "private": true,
   "scripts": {
     "dev": "webpack serve",
-    "build": "webpack --progress"
+    "build": "webpack --progress",
+    "process": "cd process && npm run process",
+    "process-all": "cd process && npm run process -- download"
   },
   "dependencies": {
     "lodash": "^4.17.21",

--- a/process/package-lock.json
+++ b/process/package-lock.json
@@ -13,6 +13,52 @@
         "lodash": "^4.17.21",
         "node-fetch": "^3.3.2",
         "sitemap": "^4.1.1"
+      },
+      "devDependencies": {
+        "@types/canvasjs": "^1.9.11",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.5.4"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@mapbox/node-pre-gyp": {
@@ -53,6 +99,41 @@
         }
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/canvasjs": {
+      "version": "1.9.11",
+      "resolved": "https://registry.npmjs.org/@types/canvasjs/-/canvasjs-1.9.11.tgz",
+      "integrity": "sha512-sx1sJS7Y9Hy/jd70Zj23xn2c5LE2tXM3Puh0aQoaMdTeHkbwueeTUeN531sepyujj47UZZGvim85DLiOjpiUeQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "12.20.55",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
@@ -70,6 +151,32 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+    },
+    "node_modules/acorn": {
+      "version": "8.12.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
+      "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.3",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.3.tgz",
+      "integrity": "sha512-MxXdReSRhGO7VlFe1bRG/oI7/mdLV9B9JJT0N8vZOhF7gFRR5l3M8W9G8JxmKV+JC5mGqJ0QvqfSOLsCPa4nUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/agent-base": {
       "version": "6.0.2",
@@ -166,6 +273,13 @@
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ=="
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
@@ -212,6 +326,16 @@
       "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/emoji-regex": {
@@ -393,6 +517,13 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/mimic-response": {
       "version": "2.1.0",
@@ -728,10 +859,75 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
@@ -780,6 +976,16 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     }
   }
 }

--- a/process/package.json
+++ b/process/package.json
@@ -4,7 +4,8 @@
   "description": "Processes files from OneHourOneLife into big JSON blobs",
   "main": "process.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "process": "npm i && node_modules/.bin/ts-node process"
   },
   "author": "",
   "license": "ISC",
@@ -13,5 +14,10 @@
     "lodash": "^4.17.21",
     "node-fetch": "^3.3.2",
     "sitemap": "^4.1.1"
+  },
+  "devDependencies": {
+    "@types/canvasjs": "^1.9.11",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.5.4"
   }
 }

--- a/process/process.ts
+++ b/process/process.ts
@@ -1,8 +1,10 @@
+
+
 if (!process.env.ONETECH_FOOD_BONUS) {
-  process.env.ONETECH_FOOD_BONUS = 0;
+  process.env.ONETECH_FOOD_BONUS = '0';
 }
 
-const MainProcessor = require('./src/MainProcessor');
+import {MainProcessor} from './src/MainProcessor';
 
 const processor = new MainProcessor(__dirname);
 

--- a/process/src/Biome.ts
+++ b/process/src/Biome.ts
@@ -1,6 +1,10 @@
 "use strict";
 
 class Biome {
+  id: any;
+  groundHeat: number;
+  objects: any[];
+
   static fromFilename(filename) {
     const id = filename.replace("ground_", "").replace(".tga", "");
     if (!id || id === "U") return;
@@ -46,7 +50,7 @@ class Biome {
   }
 
   jsonData() {
-    const result = {
+    const result: any = {
       id: this.id,
       groundHeat: this.groundHeat,
       name: this.name(),
@@ -58,4 +62,4 @@ class Biome {
   }
 }
 
-module.exports = Biome;
+export { Biome }

--- a/process/src/Category.ts
+++ b/process/src/Category.ts
@@ -1,6 +1,13 @@
 "use strict";
 
 class Category {
+  objectIDs: any[];
+  objectWeights: any[];
+  parentID: any;
+  pattern: boolean;
+  probSet: boolean;
+  parent: any;
+  objects: any[];
   constructor(dataText) {
     this.objectIDs = [];
     this.objectWeights = [];
@@ -60,4 +67,4 @@ class Category {
   }
 }
 
-module.exports = Category;
+export { Category }

--- a/process/src/ChangeLog.ts
+++ b/process/src/ChangeLog.ts
@@ -1,9 +1,13 @@
 "use strict";
 
-const Git = require('./Git');
-const ChangeLogVersion = require('./ChangeLogVersion');
+import { Git } from "./Git";
+import { ChangeLogVersion } from "./ChangeLogVersion";
 
 class ChangeLog {
+  git: Git;
+  objects: any;
+  versions: any;
+
   constructor(gitDir, objects, releasedOnly) {
     this.git = new Git(gitDir);
     this.objects = objects;
@@ -11,13 +15,13 @@ class ChangeLog {
   }
 
   fetchVersions(releasedOnly) {
-    let previousVersion = null;
+    let previousVersion: any = null;
     const versions = this.fetchVersionNumbers().map(id => {
       const version = new ChangeLogVersion(
         this.git,
         this.objects,
         id,
-        previousVersion
+        null
       );
       previousVersion = version;
       return version;
@@ -63,7 +67,7 @@ class ChangeLog {
   }
 
   reportMissing() {
-    const objects = Object.values(this.objects).filter(o => !o.version);
+    const objects = Object.values(this.objects).filter((o: any) => !o.version);
     console.log(objects.length + " objects are missing version");
     // for (let object of objects) {
     //   console.log(object.id, object.name, "unable to determine version");
@@ -71,4 +75,4 @@ class ChangeLog {
   }
 }
 
-module.exports = ChangeLog;
+export { ChangeLog }

--- a/process/src/ChangeLogCommit.ts
+++ b/process/src/ChangeLogCommit.ts
@@ -1,9 +1,22 @@
 "use strict";
 
-const GameObject = require('./GameObject');
-const Transition = require('./Transition');
+import { GameObject } from "./GameObject";
+import { Transition } from "./Transition";
 
 class ChangeLogCommit {
+  version: any;
+  git: any;
+  objects: any;
+  legacyObjects: {};
+  sha: any;
+  date: any;
+  message: any;
+  addedObjects: any[];
+  removedObjects: any[];
+  addedTransitions: any[];
+  removedTransitions: any[];
+  objectChanges: any[];
+
   constructor(version, log) {
     this.version = version;
     this.git = version.git;
@@ -173,7 +186,7 @@ class ChangeLogCommit {
   }
 
   jsonData() {
-    const data = {sha: this.sha, message: this.message, date: this.date};
+    const data: any = {sha: this.sha, message: this.message, date: this.date};
 
     if (this.addedObjects.length)
       data.addedObjectIDs = this.addedObjects.map(o => o.id);
@@ -208,4 +221,4 @@ class ChangeLogCommit {
   }
 }
 
-module.exports = ChangeLogCommit;
+export { ChangeLogCommit }

--- a/process/src/ChangeLogCommit.ts
+++ b/process/src/ChangeLogCommit.ts
@@ -7,7 +7,7 @@ class ChangeLogCommit {
   version: any;
   git: any;
   objects: any;
-  legacyObjects: {};
+  legacyObjects: any;
   sha: any;
   date: any;
   message: any;

--- a/process/src/ChangeLogVersion.ts
+++ b/process/src/ChangeLogVersion.ts
@@ -1,8 +1,13 @@
 "use strict";
 
-const ChangeLogCommit = require('./ChangeLogCommit');
+import { ChangeLogCommit } from "./ChangeLogCommit";
 
 class ChangeLogVersion {
+  git: any;
+  objects: any;
+  id: any;
+  previous: any;
+  commits: any;
   constructor(git, objects, id, previous) {
     this.git = git;
     this.objects = objects;
@@ -42,7 +47,7 @@ class ChangeLogVersion {
   }
 
   jsonData() {
-    const data = {id: this.id};
+    const data: any = {id: this.id};
     const commits = this.fetchCommits();
     if (this.isReleased() && commits[0]) {
       data.date = commits[0].date;
@@ -70,4 +75,4 @@ class ChangeLogVersion {
   }
 }
 
-module.exports = ChangeLogVersion;
+export { ChangeLogVersion }

--- a/process/src/Depth.ts
+++ b/process/src/Depth.ts
@@ -3,6 +3,10 @@
 // Depth is the deepest number of steps needed to craft an object
 // Natural and uncraftable objects have a depth of 0
 class Depth {
+  calculated: boolean;
+  value: any;
+  difficulty: any;
+  craftable: any;
   constructor({ value, difficulty, craftable }) {
     this.calculated = !isNaN(value);
     this.value = value || 0;
@@ -63,4 +67,4 @@ class Depth {
   }
 }
 
-module.exports = Depth;
+export { Depth  }

--- a/process/src/Depth.ts
+++ b/process/src/Depth.ts
@@ -4,13 +4,13 @@
 // Natural and uncraftable objects have a depth of 0
 class Depth {
   calculated: boolean;
-  value: any;
-  difficulty: any;
-  craftable: any;
-  constructor({ value, difficulty, craftable }) {
+  value: number;
+  difficulty: number;
+  craftable: boolean;
+  constructor({ value = null, difficulty = 0, craftable }) {
     this.calculated = !isNaN(value);
     this.value = value || 0;
-    this.difficulty = difficulty || 0;
+    this.difficulty = difficulty;
     this.craftable = craftable;
   }
 

--- a/process/src/DepthCalculator.ts
+++ b/process/src/DepthCalculator.ts
@@ -1,8 +1,9 @@
 "use strict";
 
-const Depth = require('./Depth');
+import { Depth } from "./Depth";
 
 class DepthCalculator {
+  objects: any;
   constructor(objects) {
     this.objects = objects;
   }
@@ -18,7 +19,7 @@ class DepthCalculator {
   calculateDepth() {
     for (let object of this.objects) {
       if (object.isNatural() || object.transitionsToward.length === 0) {
-        this.setObjectDepth(object, new Depth({value: 0, craftable: object.isNatural()}));
+        this.setObjectDepth(object, new Depth({value: 0, craftable: object.isNatural(), difficulty: 0}));
       }
     }
   }
@@ -44,7 +45,7 @@ class DepthCalculator {
   // If the depth was calculated, it sets it to the resulting object
   calculateTransition(transition) {
     // Start in true state so adding transition can make to uncraftable
-    const depth = new Depth({value: 0, craftable: true});
+    const depth = new Depth({value: 0, craftable: true, difficulty: 0});
     depth.addTransition(transition);
     transition.depth = depth;
 
@@ -79,4 +80,4 @@ class DepthCalculator {
   }
 }
 
-module.exports = DepthCalculator;
+export { DepthCalculator }

--- a/process/src/GameData.ts
+++ b/process/src/GameData.ts
@@ -20,7 +20,7 @@ class GameData {
   processDir: any;
   dataDir: any;
   staticDir: any;
-  objects: {};
+  objects: any;
   categories: any[];
   biomes: any[];
   releasedOnly: boolean;

--- a/process/src/GameData.ts
+++ b/process/src/GameData.ts
@@ -4,19 +4,27 @@ const { spawnSync } = require('child_process');
 const fs = require('fs');
 const _ = require('lodash');
 
-const GameObject = require('./GameObject');
-const Category = require('./Category');
-const TransitionImporter = require('./TransitionImporter');
-const ChangeLog = require('./ChangeLog');
-const Biome = require('./Biome');
-const DepthCalculator = require('./DepthCalculator');
-const SpriteProcessor = require('./SpriteProcessor');
-const ObjectFilters = require('./ObjectFilters');
-const ObjectBadges = require('./ObjectBadges');
-const SitemapGenerator = require('./SitemapGenerator');
-const readFileNormalized = require('./readFileNormalized');
+import { GameObject } from "./GameObject";
+import { Category } from "./Category";
+import { TransitionImporter } from "./TransitionImporter";
+import { ChangeLog } from "./ChangeLog";
+import { Biome } from "./Biome";
+import { DepthCalculator } from "./DepthCalculator";
+import { SpriteProcessor } from "./SpriteProcessor";
+import { ObjectFilters } from "./ObjectFilters";
+import { ObjectBadges } from "./ObjectBadges";
+import { SitemapGenerator } from "./SitemapGenerator";
+import { readFileNormalized } from "./readFileNormalized";
 
 class GameData {
+  processDir: any;
+  dataDir: any;
+  staticDir: any;
+  objects: {};
+  categories: any[];
+  biomes: any[];
+  releasedOnly: boolean;
+  changeLog: ChangeLog;
   constructor(processDir, dataDir, staticDir) {
     this.processDir = processDir;
     this.dataDir = dataDir;
@@ -95,7 +103,7 @@ class GameData {
         Biome.applyGroundHeat(this.biomes, filename, content);
       }
     });
-    const objects = Object.values(this.objects).filter(o => o.isNatural());
+    const objects = Object.values(this.objects).filter((o: any) => o.isNatural());
     for (let biome of this.biomes) {
       biome.addObjects(objects);
     }
@@ -112,10 +120,10 @@ class GameData {
     calculator.calculate();
   }
 
-  generateTechTree() {
-    var generator = new TechTreeGenerator();
-    generator.generate(Object.values(this.objects));
-  }
+  // generateTechTree() {
+  //   var generator = new TechTreeGenerator();
+  //   generator.generate(Object.values(this.objects));
+  // }
 
   exportObjects() {
     this.saveJSON("objects.json", this.objectsData());
@@ -177,7 +185,7 @@ class GameData {
       versions: this.changeLog.validVersions().map(v => v.id),
       biomeIds: this.biomes.map(b => b.id),
       biomeNames: this.biomes.map(b => b.name()),
-      foodEatBonus: parseInt(process.env.ONETECH_FOOD_BONUS),
+      foodEatBonus: parseInt(process.env.ONETECH_FOOD_BONUS || '0'),
     };
   }
 
@@ -234,7 +242,7 @@ class GameData {
 
   eachFileContent(dirName, extension, callback) {
     this.eachFileInDir(dirName, extension, (path, filename) => {
-      callback(readFileNormalized(path, "utf8"), filename);
+      callback(readFileNormalized(path), filename);
     });
   }
 
@@ -252,4 +260,4 @@ class GameData {
   }
 }
 
-module.exports = GameData;
+export { GameData }

--- a/process/src/GameObject.ts
+++ b/process/src/GameObject.ts
@@ -24,7 +24,7 @@ class GameObject {
     this.transitionsAway = [];
     this.categories = [];
     this.biomes = [];
-    this.depth = new Depth({craftable: false, value: 0, difficulty: 0});
+    this.depth = new Depth({craftable: false, difficulty: 0});
     this.parseData(dataText);
     if (!this.data.id)
       return;

--- a/process/src/GameObject.ts
+++ b/process/src/GameObject.ts
@@ -1,10 +1,22 @@
 "use strict";
 
-const Sprite = require('./Sprite');
-const Depth = require('./Depth');
-const Recipe = require('./Recipe');
+import { Sprite } from "./Sprite";
+import { Depth } from "./Depth";
+import { Recipe } from "./Recipe";
 
 class GameObject {
+  legacy: boolean;
+  id: any;
+  data: any;
+  sprites: any[];
+  transitionsToward: any[];
+  transitionsAway: any[];
+  categories: any[];
+  biomes: any[];
+  depth: any;
+  name: any;
+  version: any;
+  category: any;
   constructor(dataText) {
     this.data = {};
     this.sprites = [];
@@ -12,7 +24,7 @@ class GameObject {
     this.transitionsAway = [];
     this.categories = [];
     this.biomes = [];
-    this.depth = new Depth({});
+    this.depth = new Depth({craftable: false, value: 0, difficulty: 0});
     this.parseData(dataText);
     if (!this.data.id)
       return;
@@ -42,7 +54,7 @@ class GameObject {
   parseLine(line) {
     const assignments = line.split(/[,#]/);
     let attribute = null;
-    let values = [];
+    let values: any[] = [];
     for (let assignment of assignments) {
       const parts = assignment.split(/[_=]/);
       if (parts.length > 1) {
@@ -88,7 +100,7 @@ class GameObject {
     const transitionsToward = this.transitionsToward;
     const transitionsAway = this.transitionsAway.filter(t => !t.decay);
     const transitionsTimed = this.transitionsAway.filter(t => t.decay);
-    const result = {
+    const result: any = {
       id: this.id,
       name: this.name,
       transitionsToward: transitionsToward.map(t => t.jsonData()),
@@ -291,7 +303,7 @@ class GameObject {
       return null;
     if (depth == 0)
       return []; // Empty array means tree goes deeper
-    var nodes = [];
+    var nodes: any[] = [];
     if (transition.decay)
       nodes.push({decay: transition.decay});
     if (transition.actor)
@@ -308,11 +320,13 @@ class GameObject {
     };
   }
 
-  insulation() {
+  insulation(): number {
     const parts = {'h': 0.25, 't': 0.35, 'b': 0.2, 's': 0.1, 'p': 0.1};
     if (parts[this.data.clothing])
       return parts[this.data.clothing]*this.data.rValue;
+    else
+      return 0;
   }
 }
 
-module.exports = GameObject;
+export { GameObject }

--- a/process/src/Git.ts
+++ b/process/src/Git.ts
@@ -3,6 +3,7 @@
 const { spawnSync } = require('child_process');
 
 class Git {
+  dir: any;
   constructor(dir) {
     this.dir = dir;
   }
@@ -70,4 +71,4 @@ class Git {
   }
 }
 
-module.exports = Git;
+export { Git }

--- a/process/src/MainProcessor.ts
+++ b/process/src/MainProcessor.ts
@@ -1,8 +1,12 @@
 "use strict";
 
-const GameData = require('./GameData');
+import { GameData } from "./GameData";
 
 class MainProcessor {
+  processDir: any;
+  doDownload: any;
+  doSprites: any;
+  doSounds: any;
   constructor(processDir) {
     this.processDir = processDir;
   }
@@ -91,4 +95,4 @@ class MainProcessor {
   }
 }
 
-module.exports = MainProcessor;
+export { MainProcessor }

--- a/process/src/ObjectBadges.ts
+++ b/process/src/ObjectBadges.ts
@@ -1,12 +1,14 @@
 "use strict";
 
+import { GameObject } from "./GameObject";
+
 const Clothing = {
   key: "clothing",
   filter(objects) {
     return objects.filter(o => o.isClothing());
   },
-  value(object) {
-    const percent = (object.insulation()*10000).toFixed()/100
+  value(object: GameObject) {
+    const percent = Math.round(object.insulation()*10000)/100;
     return `${percent}%`;
   }
 }
@@ -18,8 +20,8 @@ const Food = {
   },
   value(object) {
     if (object.data.numUses > 1)
-      return `${object.data.foodValue[0] + object.data.foodValue[1] + parseInt(process.env.ONETECH_FOOD_BONUS)} x ${object.data.numUses}`;
-    return object.data.foodValue[0] + object.data.foodValue[1] + parseInt(process.env.ONETECH_FOOD_BONUS);
+      return `${object.data.foodValue[0] + object.data.foodValue[1] + parseInt(process.env.ONETECH_FOOD_BONUS || '0')} x ${object.data.numUses}`;
+    return object.data.foodValue[0] + object.data.foodValue[1] + parseInt(process.env.ONETECH_FOOD_BONUS || '0');
   }
 }
 
@@ -89,7 +91,7 @@ const ObjectBadges = {
     const badgesData = {};
     for (let badge of this.badges) {
       const objects = badge.filter(allObjects);
-      const data = {ids: objects.map(o => o.id)};
+      const data: any = {ids: objects.map(o => o.id)};
       if (badge.value)
         data.values = objects.map(o => badge.value(o));
       badgesData[badge.key] = data;
@@ -98,4 +100,4 @@ const ObjectBadges = {
   }
 }
 
-module.exports = ObjectBadges;
+export { ObjectBadges }

--- a/process/src/ObjectFilters.ts
+++ b/process/src/ObjectFilters.ts
@@ -211,4 +211,4 @@ const ObjectFilters = {
   }
 }
 
-module.exports = ObjectFilters;
+export { ObjectFilters }

--- a/process/src/Recipe.ts
+++ b/process/src/Recipe.ts
@@ -1,9 +1,11 @@
 "use strict";
 
-const RecipeGenerator = require('./RecipeGenerator');
-const RecipeNode = require('./RecipeNode');
+import { RecipeGenerator } from "./RecipeGenerator";
+import { RecipeNode } from "./RecipeNode";
 
 class Recipe {
+  object: any;
+  nodes: any;
   constructor(object) {
     this.object = object;
   }
@@ -22,7 +24,7 @@ class Recipe {
   }
 
   jsonData() {
-    const data = {steps: RecipeNode.steps(this.nodes)};
+    const data: any = {steps: RecipeNode.steps(this.nodes)};
 
     // For now let's just merge tools and ingredients together when displaying
     // We may eventually split them up for the user
@@ -44,7 +46,7 @@ class Recipe {
   }
 
   ingredients() {
-    const ingredients = [];
+    const ingredients: any[] = [];
     const nodes = this.nodes.filter(n => n.isIngredient());
     for (let node of nodes) {
       const count = node.count();
@@ -56,4 +58,4 @@ class Recipe {
   }
 }
 
-module.exports = Recipe;
+export { Recipe }

--- a/process/src/RecipeGenerator.ts
+++ b/process/src/RecipeGenerator.ts
@@ -1,8 +1,11 @@
 "use strict";
 
-const RecipeNode = require('./RecipeNode');
+import { RecipeNode } from "./RecipeNode";
 
 class RecipeGenerator {
+  nodes: any;
+  object: any;
+  availableTools: any[];
   constructor(object) {
     this.object = object;
     this.nodes = [];
@@ -115,4 +118,4 @@ class RecipeGenerator {
   }
 }
 
-module.exports = RecipeGenerator;
+export { RecipeGenerator }

--- a/process/src/RecipeNode.ts
+++ b/process/src/RecipeNode.ts
@@ -1,8 +1,20 @@
 "use strict";
 
 class RecipeNode {
+  transition: any;
+  object: any;
+  parents: any[];
+  children: any[];
+  decaySeconds: number;
+  tool: boolean;
+  collapsedParent: any;
+  cachedDepth: any;
+  countCache: any;
+  cachedSubNodes: any;
+  mainBranch: boolean;
+  cachedLargestChild: any;
   static steps(nodes, expand = false) {
-    const steps = [];
+    const steps: any[] = [];
     nodes = nodes.sort((a,b) => b.subNodeDepth() - a.subNodeDepth()).
                   sort((a,b) => (b.collapsedParent ? 0 : 1) - (a.collapsedParent ? 0 : 1))
     for (let node of nodes) {
@@ -254,7 +266,7 @@ class RecipeNode {
   }
 
   calculateSubNodes() {
-    let subNodes = [];
+    let subNodes: any[] = [];
     for (let child of this.uniqueChildren()) {
       if (!child.isLast()) {
         subNodes.push(child);
@@ -311,7 +323,7 @@ class RecipeNode {
     return this.cachedLargestChild;
   }
 
-  collapse(parent = null) {
+  collapse(parent: any = null) {
     // Don't collapse the main branch
     if (this.mainBranch) {
       return;
@@ -329,7 +341,7 @@ class RecipeNode {
   }
 
   jsonData(expand = false) {
-    const data = {id: this.object.id};
+    const data: any = {id: this.object.id};
     if (this.count() > 1) {
       data.count = this.count();
       data.uses = "x" + data.count;
@@ -387,4 +399,4 @@ class RecipeNode {
   }
 }
 
-module.exports = RecipeNode;
+export { RecipeNode }

--- a/process/src/SitemapGenerator.ts
+++ b/process/src/SitemapGenerator.ts
@@ -3,9 +3,10 @@
 const sm = require('sitemap');
 const fs = require('fs');
 
-const ObjectFilters = require('./ObjectFilters');
+import { ObjectFilters } from "./ObjectFilters";
 
 class SitemapGenerator {
+  rootDir: any;
   constructor(rootDir) {
     this.rootDir = rootDir;
   }
@@ -45,4 +46,4 @@ class SitemapGenerator {
   }
 }
 
-module.exports = SitemapGenerator;
+export { SitemapGenerator }

--- a/process/src/Sprite.ts
+++ b/process/src/Sprite.ts
@@ -3,6 +3,17 @@
 const fs = require('fs');
 
 class Sprite {
+  index: any;
+  object: any;
+  id: any;
+  x: any;
+  y: any;
+  rotation: any;
+  tag: any;
+  multiplicativeBlending: boolean;
+  centerAnchorXOffset: number;
+  centerAnchorYOffset: number;
+  ageRange: any;
   constructor(lines, index, object) {
     this.index = index;
     this.object = object;
@@ -15,7 +26,7 @@ class Sprite {
   parseLine(line) {
     const assignments = line.split(/[,#]/);
     let attribute = null;
-    let values = [];
+    let values: any[] = [];
     for (let assignment of assignments) {
       const parts = assignment.split(/[_=]/);
       if (parts.length > 1) {
@@ -69,4 +80,4 @@ class Sprite {
   }
 }
 
-module.exports = Sprite;
+export { Sprite }

--- a/process/src/SpriteProcessor.ts
+++ b/process/src/SpriteProcessor.ts
@@ -1,13 +1,17 @@
 "use strict";
 
-const Canvas = require('canvas');
+import * as Canvas from 'canvas';
 const fs = require('fs');
 
 class SpriteProcessor {
+  spritesDir: any;
+  pngDir: any;
+  canvas: any;
+  context: any;
   constructor(spritesDir, pngDir) {
     this.spritesDir = spritesDir;
     this.pngDir = pngDir;
-    this.canvas = new Canvas.createCanvas(512, 1024);
+    this.canvas = Canvas.createCanvas(512, 1024);
     this.context = this.canvas.getContext('2d');
   }
 
@@ -74,10 +78,10 @@ class SpriteProcessor {
     const width = bounds.maxX - bounds.minX;
     const height = bounds.maxY - bounds.minY;
 
-    const newCanvas = new Canvas.createCanvas(width, height);
+    const newCanvas = Canvas.createCanvas(width, height);
     const newContext = newCanvas.getContext('2d');
 
-    newContext.setTransform(1, 0, 0, 1, 0, 0);
+    newContext.setTransform(new Canvas.DOMMatrix([1, 0, 0, 1, 0, 0]));
 
     newContext.drawImage(
       this.canvas,
@@ -109,7 +113,7 @@ class SpriteProcessor {
   }
 
   drawSpriteWithOperation(sprite, operation) {
-    const newCanvas = new Canvas.createCanvas(this.canvas.width, this.canvas.height);
+    const newCanvas = Canvas.createCanvas(this.canvas.width, this.canvas.height);
     const newContext = newCanvas.getContext('2d');
 
     this.drawSpriteDirectly(sprite, newContext);
@@ -149,15 +153,15 @@ class SpriteProcessor {
   }
 
   overlayColor(sprite, targetContext) {
-    const newCanvas = new Canvas.createCanvas(this.canvas.width, this.canvas.height);
+    const newCanvas = Canvas.createCanvas(this.canvas.width, this.canvas.height);
     const newContext = newCanvas.getContext('2d');
 
-    this.drawSpriteImage(sprite, newContext, false)
+    this.drawSpriteImage(sprite, newContext)
 
     const color = sprite.color.map(c => Math.round(c*255)).join(", ");
 
     newContext.globalCompositeOperation = "source-in";
-    newContext.setTransform(1, 0, 0, 1, 0, 0);
+    newContext.setTransform(new Canvas.DOMMatrix([1, 0, 0, 1, 0, 0]));
     newContext.fillStyle = "rgb(" + color + ")";
     newContext.fillRect(0, 0, newCanvas.width, newCanvas.height);
 
@@ -291,4 +295,4 @@ class SpriteProcessor {
   }
 }
 
-module.exports = SpriteProcessor;
+export { SpriteProcessor }

--- a/process/src/Transition.ts
+++ b/process/src/Transition.ts
@@ -1,10 +1,38 @@
 "use strict";
 
-const Depth = require('./Depth');
+import { Depth } from "./Depth";
 
 class Transition {
+  depth: any;
+  lastUseActor: boolean;
+  lastUseTarget: boolean;
+  actorID: any;
+  targetID: any;
+  newActorID: any;
+  newTargetID: any;
+  autoDecaySeconds: any;
+  actorMinUseFraction: any;
+  targetMinUseFraction: any;
+  reverseUseActor: boolean;
+  reverseUseTarget: boolean;
+  move: number;
+  desiredMoveDist: any;
+  noUseActor: boolean;
+  noUseTarget: boolean;
+  playerActor: boolean;
+  tool: boolean;
+  targetRemains: boolean;
+  decay: string | undefined;
+  actor: any;
+  target: any;
+  newActor: any;
+  newTarget: any;
+  newExtraTarget: any;
+  newExtraTargetID: any;
+  newActorWeight: any;
+  newTargetWeight: any;
   constructor(dataText, filename) {
-    this.depth = new Depth({});
+    this.depth = new Depth({craftable: false, difficulty: 0, value: 0});
     this.parseFilename(filename);
     this.parseData(dataText);
   }
@@ -139,7 +167,7 @@ class Transition {
   }
 
   jsonData() {
-    const result = {}
+    const result: any = {}
 
     if (this.actor) {
       result.actorID = this.actor.id;
@@ -217,4 +245,4 @@ class Transition {
   }
 }
 
-module.exports = Transition;
+export { Transition }

--- a/process/src/Transition.ts
+++ b/process/src/Transition.ts
@@ -32,7 +32,7 @@ class Transition {
   newActorWeight: any;
   newTargetWeight: any;
   constructor(dataText, filename) {
-    this.depth = new Depth({craftable: false, difficulty: 0, value: 0});
+    this.depth = new Depth({craftable: false, difficulty: 0});
     this.parseFilename(filename);
     this.parseData(dataText);
   }

--- a/process/src/TransitionImporter.ts
+++ b/process/src/TransitionImporter.ts
@@ -1,8 +1,9 @@
 "use strict";
 
-const Transition = require('./Transition');
+import { Transition } from "./Transition";
 
 class TransitionImporter {
+  transitions: any;
   constructor() {
     this.transitions = [];
   }
@@ -26,7 +27,7 @@ class TransitionImporter {
   }
 
   splitCategory(category, attr, newAttr, weightAttr) {
-    const newTransitions = [];
+    const newTransitions: any[] = [];
     for (let transition of this.transitions) {
       if (transition[attr] == category.parentID || transition[newAttr] == category.parentID) {
         for (let id of category.objectIDs) {
@@ -112,7 +113,7 @@ class TransitionImporter {
 
   // Generic transitions are played along with another successful transition of the same actor
   mergeGenericTransitions() {
-    const newTransitions = [];
+    const newTransitions: any[] = [];
     for (let transition of this.transitions) {
       if (transition.isGeneric()) {
         this.mergeGenericTransition(transition, newTransitions);
@@ -159,7 +160,7 @@ class TransitionImporter {
   }
 
   mergeAttackTransitions() {
-    const newTransitions = [];
+    const newTransitions: any[] = [];
     for (let transition of this.transitions) {
       if (transition.targetID === "0") {
         if (!transition.lastUseActor && !transition.lastUseTarget) {
@@ -211,10 +212,10 @@ class TransitionImporter {
   // "towards" transition. This looks for a transmitter which
   // has "*global1" in the name and adds this as an extra object
   addGlobalTriggers(objects) {
-    const triggers = Object.values(objects).filter(o => o.isGlobalTrigger());
+    const triggers: any[] = Object.values(objects).filter((o: any) => o.isGlobalTrigger());
     for (let trigger of triggers) {
       const transmitterName = trigger.transmitterName();
-      const transmitters = Object.values(objects).filter(o => o.name.includes(transmitterName));
+      const transmitters: any[] = Object.values(objects).filter((o: any) => o.name.includes(transmitterName));
       for (let transmitter of transmitters) {
         for (let transition of transmitter.transitionsToward) {
           transition.newExtraTargetID = trigger.id;
@@ -225,4 +226,4 @@ class TransitionImporter {
   }
 }
 
-module.exports = TransitionImporter;
+export { TransitionImporter }

--- a/process/src/readFileNormalized.ts
+++ b/process/src/readFileNormalized.ts
@@ -6,4 +6,4 @@ function readFileNormalized(path) {
   return fs.readFileSync(path, "utf8").replaceAll('\r\n', '\n');
 }
 
-module.exports = readFileNormalized;
+export { readFileNormalized }

--- a/process/tsconfig.json
+++ b/process/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "outDir": "./built",
+    "allowJs": true,
+    "target": "es5",
+  },
+  "include": [
+    "./src/**/*"
+  ]
+}


### PR DESCRIPTION
As an experiment, I moved all the Javascript code in `process` over to Typescript.

To keep things just like the original code in terms of logic, types, etc, I used the `any` type everywhere where a type annotation was required.

I tested a full processing run with the download option, and had some very interesting results!

The web page looks good, so no problems there. What's interesting is that the Typescript processing took about 15% less time to do the processing! On my machine this gave me back about a minute (from 6m25s to 5m25s on average) on each process run (no download, sprites, or sounds), which is awesome for debugging.

I haven't yet gathered metrics on the `download` processing option, since it takes longer, but I'll get that data in here soon.

Keep in mind that this is with as many `any` types being used as needed. Another benefit of using Typescript is that we could start nailing down what some of these types are, removing a LOT of guesswork when trying to modify the code.

I understand moving the code over to Typescript is a big change. This MR is aimed at trying to prove it's something worth doing.
If it's accepted, even better. But I know that would require a lot of confidence from others that everything is still functional.