### PR TITLE
Fix regressions from Vue 3 and Typescript upgrades

### DIFF
--- a/process/src/ChangeLogCommit.ts
+++ b/process/src/ChangeLogCommit.ts
@@ -250,7 +250,6 @@ interface ExportedChangeLogCommitData {
   date: Date;
   addedObjectIDs?: string[];
   removedObjectIDs?: string[];
-  // TODO: Change this to ExportedTransitionData when it gets defined.
   addedTransitions?: ExportedTransitionData[];
   removedTransitions?: ExportedTransitionData[];
   objectChanges?: ObjectChange[];

--- a/process/src/GameData.ts
+++ b/process/src/GameData.ts
@@ -125,11 +125,6 @@ class GameData {
     calculator.calculate();
   }
 
-  // generateTechTree() {
-  //   var generator = new TechTreeGenerator();
-  //   generator.generate(Object.values(this.objects));
-  // }
-
   exportObjects(): void {
     this.populateFilters();
     this.saveJSON("objects.json", this.objectsJsonData());

--- a/process/src/GameObject.ts
+++ b/process/src/GameObject.ts
@@ -199,14 +199,6 @@ class GameObject {
     this.assignData(attribute, values);
   }
 
-  // parseValue(value) {
-  //   if (isNaN(value))
-  //     return value;
-  //   if (value.includes("."))
-  //     return parseFloat(value);
-  //   return parseInt(value);
-  // }
-
   assignData(attribute: string, values: string[]): void {
     if (!attribute) return;
     // Parse attributes. Try to keep this alphabetized, for sanity's sake

--- a/process/src/MainProcessor.ts
+++ b/process/src/MainProcessor.ts
@@ -149,6 +149,7 @@ class MainProcessor {
       console.time("Generating sitemap took");
       gameData.generateSitemap();
       console.timeEnd("Generating sitemap took");
+      console.timeEnd("Processing took");
       return null;
     }
 

--- a/src/components/BiomeInspector.vue
+++ b/src/components/BiomeInspector.vue
@@ -99,12 +99,6 @@ export default defineComponent({
 
 <style lang="scss">
 .biomeInspector {
-  .loading {
-    text-align: center;
-    padding: 20px;
-    font-size: 18px;
-    color: #aaa;
-  }
   .biomes {
     background-color: #222;
     border-radius: 5px;

--- a/src/components/BiomeList.vue
+++ b/src/components/BiomeList.vue
@@ -7,7 +7,7 @@
       v-tippy="{theme: 'twotech', animation: 'scale'}"
       class="biome"
       :key="biome.id"
-      :class="{ selected: biome === selectedBiome }"
+      :class="{ selected: biome?.name === selectedBiome?.name }"
       ref="biomeLink"
     >
       <BiomeImage :biome="biome" />

--- a/src/components/ObjectInspector.vue
+++ b/src/components/ObjectInspector.vue
@@ -154,12 +154,16 @@ export default defineComponent({
   setup() {
     const route = useRoute();
     const router = useRouter();
-    const object = ref(null);
+    const object = ref(GameObject.find(route.params.id));
     const loading = ref(true);
 
     const loadObject = async () => {
+      // Set basic data to new GameObject, so loading screen has correct object's data
+      object.value = GameObject.find(route.params.id);
+      // Set loading flag while we're loading the full item data
       loading.value = true;
       object.value = await GameObject.findAndLoad(route.params.id);
+      // Item data is loaded, and the page is ready to be shown
       loading.value = false;
       if (!object.value) {
         router.replace("/not-found");
@@ -243,6 +247,10 @@ export default defineComponent({
       return `Holds ${object.value.data.numSlots} ${object.value.slotSize()} items`;
     });
 
+    const isLetterOrSign = computed(() => {
+      return object.value.name.includes("Letter") || object.value.name.includes("Sign");
+    });
+
     const pickupText = computed(() => {
       if (!object.value?.data?.minPickupAge) return;
       return `Pickup at Age: ${object.value.data.minPickupAge}`;
@@ -308,6 +316,7 @@ export default defineComponent({
       useWord,
       sizeText,
       containerText,
+      isLetterOrSign,
       pickupText,
       speedPercent,
       modName,

--- a/src/components/ObjectSearch.vue
+++ b/src/components/ObjectSearch.vue
@@ -53,7 +53,6 @@ export default {
         } else {
           let newSelectedObject = GameObject.find(route?.params?.id.split('-')[0]);
           selectedObject.value = GameObject.find(route?.params?.id.split('-')[0]);
-          if (VueSelectElem.value) VueSelectElem.value.search = newSelectedObject.name;
           if (VueSelectElem.value) VueSelectElem.value.mutableValue = newSelectedObject.name;
         }
       }),
@@ -67,7 +66,8 @@ export default {
         newSelectedObject = object;
       }
       if (newSelectedObject === selectedObject.value) return;
-      router.push(newSelectedObject ? newSelectedObject.url() : '/');
+      if (newSelectedObject)
+        router.push(newSelectedObject.url());
     };
 
     return {


### PR DESCRIPTION
This PR fixes regressions found during the testing for the Vue 3 / Typescript migration.

It should satisfy all the concerns found in issue: https://github.com/twohoursonelife/twotech/issues/63

* Fix object inspector loading so it shows object name and picture while loading full data
* Remove some old/outdated comments
* Fix shadow in search box when on an object page
* Add missing timeEnd for processing code in case where version isn't supplied
* Fix missing Sign Letters link, and the link works from Object pages
* Selected Biome how has white rim around image on Biome List