### PR TITLE
Make object filters include uncraftable objects when 'only craftable'…

### DIFF
--- a/process/src/GameObject.ts
+++ b/process/src/GameObject.ts
@@ -430,7 +430,7 @@ class GameObject {
   }
 
   canFilter(): boolean {
-    return this.depth.craftable && !this.isGlobalTrigger();
+    return !this.isGlobalTrigger() && this.isVisible();
   }
 
   sounds(): number[] {


### PR DESCRIPTION
… is unticked. Fixes twohoursonelife/twotech#98