### PR TITLE
Improve filter button usability and alignment

### DIFF
--- a/src/components/ObjectFilter.vue
+++ b/src/components/ObjectFilter.vue
@@ -23,7 +23,12 @@ export default defineComponent({
   },
   setup(props) {
     const url = computed(() => {
-      return props.selected ? '/' : `${props.filter.path}`;
+      if (props.selected) {
+        const parts = props.filter.path.split('/');
+        parts.pop();
+        return parts.join('/') || '/';
+      }
+      return props.filter.path;
     });
 
     return { url };
@@ -46,20 +51,20 @@ export default defineComponent({
 
   .objectFilter h3 {
     text-align: center;
-    margin: 10px 5px;
+    margin: 10px 30px;
   }
 
   .objectFilter .deselect {
     position: absolute;
-    right: 15px;
-    top: 13px;
-    width: 20px;
-    height: 20px;
+    right: 5px;
+    top: 11px;
+    width: 22px;
+    height: 22px;
     border-radius: 10px;
     font-size: 16px;
     background-color: #555;
     font-weight: bold;
-    line-height: 18px;
+    line-height: 22px;
     text-align: center;
   }
 
@@ -77,9 +82,13 @@ export default defineComponent({
     .objectFilter.selected:hover {
       background-color: #777;
     }
+    
+    .objectFilter .deselect {
+      display: none;
+    }
 
     .objectFilter:hover .deselect {
-      background-color: #222;
+      display: inline;
     }
   }
 
@@ -97,8 +106,8 @@ export default defineComponent({
     }
 
     .objectFilter .deselect {
-      right: 8px;
-      top: 11px;
+      right: 4px;
+      top: 8px;
     }
   }
 </style>


### PR DESCRIPTION
Previously clicking a sub-filter eg. "shoe", would clear all filters and return the user to the main page. Clicking that button would now instead clear the sub-filter, leaving the user on the "clothing" filter page.

Also adjusted some positioning to allow the small x that appears over selected filters, to display on the right of the filter name. Selected filters still appear grey, but the x only appears if the button is hovered.

Note: I am vision impaired and because of this, many settings on my computer increase the size and scale of my programs. I have made my best effort to ensure that my CSS changes appear correctly, including checking multiple browsers, however this should be checked on a computer that does not have these settings before merging. 

### Changes displayed in Brave browser:
Main filter selected, hovered:
<img width="1354" height="454" alt="image" src="https://github.com/user-attachments/assets/f939da15-cc6c-403f-8b0b-2c3a382f6d60" />
Sub-filter selected, hovered:
<img width="1354" height="443" alt="image" src="https://github.com/user-attachments/assets/a0dc7379-2e7e-430f-954a-c78a38d69be7" />
Sub-filter selected, not hovered:
<img width="1354" height="764" alt="image" src="https://github.com/user-attachments/assets/f6d029f5-e70b-42c9-b5c8-f5532e66aaea" />
