### PR TITLE
Fix uncraftable toggle

### DIFF
--- a/src/components/ObjectInspector.vue
+++ b/src/components/ObjectInspector.vue
@@ -163,60 +163,19 @@ export default {
     const router = useRouter();
     const object = ref(GameObject.find(route.params.id));
     const loading = ref(true);
-    const filteredTransitionsToward = computed(() => {
-      if (loading.value === false) {
-        if (!object.value.data.transitionsToward) return [];
-        if (typeof object.value.data.transitionsToward !== "object") return [];
-        // If hideUncraftable is toggled, filter out transitions with actors or targets that are not craftable
-        if (props.hideUncraftable) {
-          return object.value.data.transitionsToward.filter(t => {
-            const actor = GameObject.find(t.actorID);
-            const target = GameObject.find(t.targetID);
-            return ((!actor || actor.craftable) && (!target || target.craftable));
-          });
-        } else {
-          return object.value.data.transitionsToward;
-        }
-      } else {
-        return [];
-      }
-    });
-    const filteredTransitionsAway = computed(() => {
-      if (loading.value === false) {
-        if (!object.value.data.transitionsAway) return [];
-        if (typeof object.value.data.transitionsAway !== "object") return [];
-        // If hideUncraftable is toggled, filter out transitions with actors or targets that are not craftable
-        if (props.hideUncraftable) {
-          return object.value.data.transitionsAway.filter(t => {
-            const actor = GameObject.find(t.actorID);
-            const target = GameObject.find(t.targetID);
-            return ((!actor || actor.craftable) && (!target || target.craftable));
-          });
-        } else {
-          return object.value.data.transitionsAway;
-        }
-      } else {
-        return [];
-      }
-    });
-    const filteredTransitionsTimed = computed(() => {
-      if (loading.value === false) {
-        if (!object.value.data.transitionsTimed) return [];
-        if (typeof object.value.data.transitionsTimed !== "object") return [];
-        // If hideUncraftable is toggled, filter out transitions with actors or targets that are not craftable
-        if (props.hideUncraftable) {
-          return object.value.data.transitionsTimed.filter(t => {
-            const actor = GameObject.find(t.actorID);
-            const target = GameObject.find(t.targetID);
-            return ((!actor || actor.craftable) && (!target || target.craftable));
-          });
-        } else {
-          return object.value.data.transitionsTimed;
-        }
-      } else {
-        return [];
-      }
-    });
+    const objectTransitions = (key) => {
+      // If we're still loading, don't try to access the object data yet
+      if (loading.value) return [];
+      const transitions = object.value?.data?.[key];
+      // If the object doesn't have any transitions, return an empty array
+      if (!transitions || typeof transitions !== "object") return [];
+      // Return transitions as an array of objects
+      return transitions;
+    };
+    // Filtered transitions for each type of transition
+    const filteredTransitionsToward = computed(() => objectTransitions("transitionsToward"));
+    const filteredTransitionsAway = computed(() => objectTransitions("transitionsAway"));
+    const filteredTransitionsTimed = computed(() => objectTransitions("transitionsTimed"));
 
     const loadObject = async () => {
       // Set basic data to new GameObject, so loading screen has correct object's data

--- a/src/components/ObjectInspector.vue
+++ b/src/components/ObjectInspector.vue
@@ -24,6 +24,12 @@
       </div>
 
       <ul v-if="!loading && object.data">
+        <li v-if="hasTransitions" class="transitionFilterToggle">
+          <label>
+            <input type="checkbox" v-model="hideUncraftableTransitions" />
+            Hide uncraftable transitions
+          </label>
+        </li>
         <li v-if="foodWithBothBonus">
           Food: {{ foodBase }}
           <span class="details"> + {{ foodBaseBonus }} bonus</span>
@@ -163,21 +169,36 @@ export default {
     const router = useRouter();
     const object = ref(GameObject.find(route.params.id));
     const loading = ref(true);
+    const hideUncraftableTransitions = ref(false);
+
+    const transitionInputsAreCraftable = (transition) => {
+      const actor = GameObject.find(transition.actorID);
+      const target = GameObject.find(transition.targetID);
+      return ((!actor || actor.craftable) && (!target || target.craftable));
+    };
+
     const objectTransitions = (key) => {
-      // If we're still loading, don't try to access the object data yet
       if (loading.value) return [];
       const transitions = object.value?.data?.[key];
-      // If the object doesn't have any transitions, return an empty array
-      if (!transitions || typeof transitions !== "object") return [];
-      // Return transitions as an array of objects
-      return transitions;
+      if (!Array.isArray(transitions)) return [];
+      if (!hideUncraftableTransitions.value) return transitions;
+      return transitions.filter(transitionInputsAreCraftable);
     };
+
+    const hasTransitions = computed(() => {
+      if (loading.value) return false;
+      return ["transitionsToward", "transitionsAway", "transitionsTimed"].some((key) => {
+        return Array.isArray(object.value?.data?.[key]) && object.value.data[key].length > 0;
+      });
+    });
+
     // Filtered transitions for each type of transition
     const filteredTransitionsToward = computed(() => objectTransitions("transitionsToward"));
     const filteredTransitionsAway = computed(() => objectTransitions("transitionsAway"));
     const filteredTransitionsTimed = computed(() => objectTransitions("transitionsTimed"));
 
     const loadObject = async () => {
+      hideUncraftableTransitions.value = false;
       // Set basic data to new GameObject, so loading screen has correct object's data
       object.value = GameObject.find(route.params.id);
       // Set loading flag while we're loading the full item data
@@ -366,6 +387,8 @@ export default {
     return {
       object,
       loading,
+      hideUncraftableTransitions,
+      hasTransitions,
       biomes,
       spawnText,
       difficultyText,
@@ -471,6 +494,18 @@ export default {
   }
   .objectInspector .info li .details {
     color: #999;
+  }
+  .objectInspector .info li.transitionFilterToggle {
+    padding: 6px 0 10px;
+  }
+  .objectInspector .transitionFilterToggle label {
+    color: #ddd;
+    cursor: pointer;
+    font-size: 1rem;
+  }
+  .objectInspector .transitionFilterToggle input {
+    margin-right: 6px;
+    vertical-align: 1px;
   }
 
   .objectInspector .actions {

--- a/src/components/ObjectInspector.vue
+++ b/src/components/ObjectInspector.vue
@@ -24,10 +24,11 @@
       </div>
 
       <ul v-if="!loading && object.data">
+        <!-- Show the transition filter toggle only if the object has any transitions -->
         <li v-if="hasTransitions" class="transitionFilterToggle">
           <label>
             <input type="checkbox" v-model="hideUncraftableTransitions" />
-            Hide uncraftable transitions
+            Only craftable transitions
           </label>
         </li>
         <li v-if="foodWithBothBonus">
@@ -169,22 +170,29 @@ export default {
     const router = useRouter();
     const object = ref(GameObject.find(route.params.id));
     const loading = ref(true);
+    // By default, item pages will show all transitions on each page load
     const hideUncraftableTransitions = ref(false);
 
     const transitionInputsAreCraftable = (transition) => {
       const actor = GameObject.find(transition.actorID);
       const target = GameObject.find(transition.targetID);
+      // Actor and target must be either craftable or not exist (for transitions that don't have an actor or target)
       return ((!actor || actor.craftable) && (!target || target.craftable));
     };
 
     const objectTransitions = (key) => {
+      // If we're still loading, don't try to access the object data yet
       if (loading.value) return [];
       const transitions = object.value?.data?.[key];
-      if (!Array.isArray(transitions)) return [];
+      // If the object doesn't have any transitions, return an empty array
+      if (!transitions || typeof transitions !== "object") return [];
+      // If we're not hiding uncraftable transitions, return all transitions
       if (!hideUncraftableTransitions.value) return transitions;
+      // Otherwise, filter the transitions to only include those that are craftable
       return transitions.filter(transitionInputsAreCraftable);
     };
 
+    // Check if the object has any transitions of any type
     const hasTransitions = computed(() => {
       if (loading.value) return false;
       return ["transitionsToward", "transitionsAway", "transitionsTimed"].some((key) => {


### PR DESCRIPTION
This addresses #126, showing uncraftable transitions by default on all item pages.

Additionally, item pages now have their own checkbox (default unchecked on each page load) for showing only craftable transitions.