### PR TITLE
Fix versions page(s)

### DIFF
--- a/process/src/ChangeLogCommit.ts
+++ b/process/src/ChangeLogCommit.ts
@@ -124,7 +124,11 @@ class ChangeLogCommit {
     if (this.legacyObjects[id])
       return this.legacyObjects[id];
 
-    const data = this.fileContent(path, mode);
+    const sha = (mode == "D" ? `${this.sha}^` : this.sha);
+    // Create minimal object for unknown objects, so there's something to reference.
+    const data = this.git.fileExists(sha, path)
+      ? this.git.fileContent(sha, path)
+      : `id=${id}\nUnknown object ${id}`;
 
     const object = new GameObject(data);
     object.legacy = true;

--- a/process/src/ChangeLogCommit.ts
+++ b/process/src/ChangeLogCommit.ts
@@ -121,6 +121,13 @@ class ChangeLogCommit {
       return this.objects[id];
     }
 
+    // Renumbered objects should use their current sprite and link, not a legacy placeholder.
+    // Legacy objects are only for objects that have been removed from the current version, not for objects that have been renumbered.
+    const currentPath = this.git.currentPath(this.sha, path);
+    const currentID = currentPath.split("/")[1].split(".")[0];
+    if (this.objects[currentID])
+      return this.objects[currentID];
+
     if (this.legacyObjects[id])
       return this.legacyObjects[id];
 

--- a/process/src/GameData.ts
+++ b/process/src/GameData.ts
@@ -137,11 +137,11 @@ class GameData {
     this.filters.setupFilters(Object.values(this.objects));
   }
 
-  exportVersions(): void {
+  exportVersions(force: boolean): void {
     const versions = this.changeLog.versions.slice().reverse();
     for (let version of versions) {
       const path = `versions/${version.id}.json`;
-      if (version.isUnreleased() || parseInt(version.id) > 0 && !fs.existsSync(this.staticDir + "/" + path)) {
+      if (force || version.isUnreleased() || parseInt(version.id) > 0 && !fs.existsSync(this.staticDir + "/" + path)) {
         this.saveJSON(path, version.jsonData());
       }
     }

--- a/process/src/Git.ts
+++ b/process/src/Git.ts
@@ -8,15 +8,22 @@ interface ChangeLogEntry {
   message: string,
 }
 
+interface FileRename {
+  path: string,
+  commitIndex: number,
+}
+
 class Git {
   dir: string;
+  fileRenames?: Record<string, FileRename[]>;
+  commitIndexes?: Record<string, number>;
   constructor(dir: string) {
     this.dir = dir;
   }
 
   run(...args: string[]): string {
     const result = spawnSync("git", args, {cwd: this.dir, encoding: 'utf8'});
-    if (result.status > 0) {
+    if (result.status !== 0) {
       console.log("Git command failed with args", args);
       console.log(result.stderr);
       console.trace();
@@ -42,6 +49,75 @@ class Git {
     return this.runLines("ls-tree", "--name-only", sha, "--", path).includes(path);
   }
 
+  /**
+   * Resolve an object path from a historical commit to the path it has at HEAD.
+   * Object IDs can be renumbered and later reused, so a single old-to-new map is
+   * not enough: each rename must also be tied to its place in commit history.
+   */
+  currentPath(sha: string, path: string): string {
+    let fileRenames = this.fileRenames;
+    let commitIndexes = this.commitIndexes;
+    if (!fileRenames || !commitIndexes) {
+      // Building the rename history runs two Git commands, so cache it for later lookups.
+      const newFileRenames: Record<string, FileRename[]> = {};
+      const newCommitIndexes: Record<string, number> = {};
+
+      // rev-list returns newest first: HEAD is index 0 and older commits have larger
+      // indexes. Therefore a rename index less than or equal to a source commit index
+      // happened at or after that source commit.
+      this.runLines("rev-list", "HEAD").forEach((commit, index) => {
+        newCommitIndexes[commit] = index;
+      });
+
+      let commitIndex: number | undefined = undefined;
+
+      // Emit each commit SHA followed by only the object renames in that commit.
+      const lines = this.runLines("-c", "diff.renameLimit=10000", "log", "--format=commit:%H", "--name-status", "--find-renames", "--diff-filter=R", "--", "objects/");
+      for (const line of lines) {
+        // Each section begins with a commit line, followed by the renames in that commit.
+        if (line.startsWith("commit:")) {
+          commitIndex = newCommitIndexes[line.slice(7)];
+          continue;
+        }
+
+        // A rename line is "R<score> <old path> <new path>" (where score is how similar the old and new files are after the rename). Keep every rename
+        // for an old path because the same numeric object path may be reused later,
+        // and we won't know what rename to follow without the commit index to go along with it (making it unique).
+        const parts = line.split(/\s+/);
+        if (parts.length == 3 && parts[0].startsWith("R") && commitIndex !== undefined) {
+          if (!newFileRenames[parts[1]])
+            newFileRenames[parts[1]] = [];
+          newFileRenames[parts[1]].push({path: parts[2], commitIndex: commitIndex});
+        }
+      }
+
+      // Update both the instance cache and the non-optional local references.
+      this.fileRenames = fileRenames = newFileRenames;
+      this.commitIndexes = commitIndexes = newCommitIndexes;
+    }
+
+    let commitIndex = commitIndexes[sha];
+    if (commitIndex === undefined)
+      return path;
+
+    // Of the renames at or after the source commit, the largest index is the first on 
+    // chronologically (because git rev-list returned newest first). After following it, use its index
+    // as the new upper bound and repeat to follow chains such as original ID -> interim ID 1 -> ... -> current ID.
+    const visited = new Set<string>();
+    while (!visited.has(path)) {
+      const rename = fileRenames[path]
+        ?.filter(rename => rename.commitIndex <= commitIndex)
+        .sort((a, b) => b.commitIndex - a.commitIndex)[0];
+      if (!rename)
+        break;
+
+      visited.add(path);
+      path = rename.path;
+      commitIndex = rename.commitIndex;
+    }
+    return path;
+  }
+
   fileContent(sha: string, path: string): string {
     // Another unpleasant fix for Data7 issues.
     // https://github.com/twohoursonelife/twotech/issues/15
@@ -59,7 +135,10 @@ class Git {
   log(from: string, to: string): ChangeLogEntry[] {
     const lines = this.runLines("log", "--format=%H %ad %s", "--date=iso-strict", `${from}..${to}`);
     return lines.map(line => {
-      const parts = line.match(/^(.+?) (.+?) (.+?)$/).slice(1);
+      const match = line.match(/^(.+?) (.+?) (.+?)$/);
+      if (!match)
+        throw new Error(`Unexpected git log output: ${line}`);
+      const parts = match.slice(1);
       return {
         sha: parts[0],
         date: new Date(parts[1]),

--- a/process/src/Git.ts
+++ b/process/src/Git.ts
@@ -38,19 +38,11 @@ class Git {
     return this.runLines("diff", "--name-status", `${from}..${to}`).map(line => line.split(/\s+/));
   }
 
+  fileExists(sha: string, path: string): boolean {
+    return this.runLines("ls-tree", "--name-only", sha, "--", path).includes(path);
+  }
+
   fileContent(sha: string, path: string): string {
-    // Dear future reader
-    // Curse object 8316. This is a last ditch effort to fix it.
-    // Broken commit causing errors. An object was removed before all references to it was.
-    // https://github.com/twohoursonelife/OneLifeData7/commit/8833527cbbb2d5d3d65f174a7d412cfa7fe5cbbe
-    if (path == "objects/8316.txt") {
-      path = "objects/8317.txt";
-    }
-
-    if (path == "objects/13507.txt") {
-      path = "objects/8317.txt"
-    }
-
     // Another unpleasant fix for Data7 issues.
     // https://github.com/twohoursonelife/twotech/issues/15
     if (path == "transitions/11104_11110_CONT") {

--- a/process/src/MainProcessor.ts
+++ b/process/src/MainProcessor.ts
@@ -150,8 +150,10 @@ class MainProcessor {
     gameData.exportObjects();
     console.timeEnd("Exporting objects took");
 
-    // console.log("\nExporting versions...");
-    // gameData.exportVersions();
+    console.log("\nExporting versions...");
+    console.time("Exporting versions took");
+    gameData.exportVersions();
+    console.timeEnd("Exporting versions took");
 
     console.log("\nExporting biomes...");
     console.time("Exporting biomes took");

--- a/process/src/MainProcessor.ts
+++ b/process/src/MainProcessor.ts
@@ -152,7 +152,7 @@ class MainProcessor {
 
     console.log("\nExporting versions...");
     console.time("Exporting versions took");
-    gameData.exportVersions();
+    gameData.exportVersions(!this.doDownload);
     console.timeEnd("Exporting versions took");
 
     console.log("\nExporting biomes...");

--- a/src/components/ChangeLogVersion.vue
+++ b/src/components/ChangeLogVersion.vue
@@ -15,23 +15,26 @@
 </template>
 
 <script>
-import { defineComponent, ref, computed, onMounted } from 'vue';
+import { defineComponent, ref, computed } from 'vue';
 import Version from '../models/Version';
 import ChangeLogCommit from './ChangeLogCommit';
 
 export default defineComponent({
   props: {
-    id: String,
+    id: {
+      type: String,
+      required: true,
+    },
   },
   components: {
     ChangeLogCommit,
   },
   setup(props) {
-    const version = ref(null);
-
-    onMounted(() => {
-      version.value = Version.fetch(props.id);
-    });
+    // Fetch the version data based on the provided id prop
+    // Do this instead of onMounted so that the data is available immediately for rendering
+    // If we set this to ref(null) and then fetch in onMounted, the component will render once with null data for version,
+    // which means date and isEmptyUnreleased will attempt to access properties of null and throw an error. By fetching the version data immediately, we avoid this issue.
+    const version = ref(Version.fetch(props.id));
 
     const date = computed(() => {
       if (!version.value?.data?.date) return;

--- a/src/models/Version.js
+++ b/src/models/Version.js
@@ -1,3 +1,5 @@
+import { reactive } from 'vue';
+
 export default class Version {
   static fetch(id) {
     if (!id) return;
@@ -5,8 +7,12 @@ export default class Version {
       this.versionsMap = {};
     if (this.versionsMap[id])
       return this.versionsMap[id];
-    const version = new Version(id);
+    // Create a reactive version instance and store it in the versionsMap
+    // This ensures that when loadData fetches the data and updates the version instance,
+    // any components using this version will reactively update as well.
+    const version = reactive(new Version(id));
     this.versionsMap[id] = version;
+    version.loadData();
     return version;
   }
 
@@ -24,7 +30,6 @@ export default class Version {
     this.id = id;
     this.data = null;
     this.loading = false;
-    this.loadData();
   }
 
   loadData() {


### PR DESCRIPTION
Targets #53.

The PR fixes a couple issues:

1. Cursed objects like 8316 and 13507 are handled as an `Unknown object` and are given a minimal dataset (just their cursed ID and the name `Unknown object`) so they don't break the rest of the changelog parsing.

2. Objects that have had their numbers changed were not showing up correctly in the version history, because the current object IDs for an object wouldn't match the object ID used back in that old version's commit.

To fix this, the history of changes to an object's ID is followed and mapped from the point it was added to the current version, and this map is used to show the correct object in the version's history. An important bit is keeping the commit and new object ID as a connected set of information (a tuple) so we don't confused re-used object IDs.

E.g. `Bed` was originally ID `22178`, but in commit `2cd838ba` it was changed to `17619`. If we know this, we can map references to ID `22178` in commits prior to `2cd838ba` (but after the object was added) to `17619` and properly show a bed.

Example screenshot of the /versions page (I collapsed the most recent few versions):
<img width="1187" height="907" alt="image" src="https://github.com/user-attachments/assets/495bd55a-a014-4312-91d8-d419d4b41e07" />
