### PR TITLE
Don't use Vue3 v-model in conjunction with older style :value convention

### DIFF
--- a/src/components/ObjectSearch.vue
+++ b/src/components/ObjectSearch.vue
@@ -5,7 +5,7 @@
       label="lowerCaseName"
       :use-guessing-engine="true"
       :options="objects"
-      v-model="selectedObject"
+      :value="selectedObject"
       @change="selectObject"
       :placeholder="placeholderVal"
     >
@@ -43,19 +43,11 @@ export default {
     const selectedObject = ref(GameObject.find(route.params.id));
     const objects = computed(() => GameObject.byNameLength(props.hideUncraftable));
 
-    watch(
-      (route, (to, from) => {
-        if (VueSelectElem.value) VueSelectElem.value.search = "";
-        if (Object.keys(route.params).length <= 0) {
-          if (VueSelectElem.value) VueSelectElem.value.search = "";
-          if (VueSelectElem.value) VueSelectElem.value.mutableValue = null;
-          placeholderVal.value = "Search";
-        } else if (route.params.id) {
-          let newSelectedObject = GameObject.find(route.params.id.split('-')[0]);
-          if (VueSelectElem.value) VueSelectElem.value.mutableValue = newSelectedObject;
-        }
-      }),
-    );
+    watch(() => route.params.id, (id) => {
+      if (VueSelectElem.value) VueSelectElem.value.search = "";
+      selectedObject.value = id ? GameObject.find(id.split('-')[0]) : null;
+      placeholderVal.value = "Search";
+    });
 
     const selectObject = (object) => {
       let newSelectedObject = null;


### PR DESCRIPTION
Targets #99.

`v-model` is a newer Vue 3 thing, which I had tried to use in the Vue 3 conversion.

However, it was being mixed with the older (still valid) convention of using `:value`.

I removed the `v-model` usage, since we use `:value` everywhere else, and there's a comment that mentioned `v-model` not working on mobile.