### PR TITLE
Webpage header title now changes based on content being shown

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,7 +1,7 @@
 <template>
   <div id="app">
     <h1>
-      <router-link to="/">Crafting Reference for {{ gameName }}</router-link>
+      <router-link to="/">{{ pageTitle }}</router-link>
     </h1>
 
     <h2 v-if="loading">Loading...</h2>
@@ -60,11 +60,6 @@ import NotFound from './components/NotFound';
 const loading = ref(true);
 const router = useRouter();
 
-useHead({
-  title: 'Crafting reference for Two Hours One Life',
-  titleTemplate: '%s | twotech',
-});
-
 const lastDate = computed(() => {
   const months = [
     'January', 'February', 'March',
@@ -97,6 +92,32 @@ const showWhatsNew = computed(() => {
 
 const gameName = computed(() => process.env.ONETECH_MOD_NAME || 'Two Hours One Life');
 
+const defaultTitle = computed(() => "Crafting reference for " + gameName.value);
+
+const pageTitle = computed(() => {
+  const route = router.currentRoute.value;
+  if (route.meta.title) return route.meta.title;
+  if (loading.value) return defaultTitle.value;
+
+  switch (route.meta.titleFrom) {
+    case 'filter':
+      return GameObject.findFilter(filterParamParts(route.params.filter))?.name || defaultTitle.value;
+    case 'version':
+      return `Version ${route.params.id}`;
+    case 'biome':
+      return Biome.find(route.params.id)?.name || defaultTitle.value;
+    case 'object':
+      return objectTitle(route.params.id, route.meta.titleSuffix);
+    default:
+      return defaultTitle.value;
+  }
+});
+
+useHead({
+  title: pageTitle,
+  titleTemplate: "%s | twotech",
+});
+
 const gameUrl = computed(() => process.env.ONETECH_MOD_URL);
 
 const onEdge = computed(() => global.edge);
@@ -116,6 +137,15 @@ function redirectOldHash() {
     path.unshift([path.shift(), path.shift()].join('-'));
   }
   router.replace('/' + path.join('/'));
+}
+
+function filterParamParts(filter) {
+  return Array.isArray(filter) ? [...filter] : filter;
+}
+
+function objectTitle(id, suffix = "") {
+  const object = GameObject.find(id);
+  return object ? object.name + suffix : defaultTitle.value;
 }
 
 function unreleasedContentUrl() {

--- a/src/main.js
+++ b/src/main.js
@@ -28,17 +28,19 @@ app.use(VueTippy, {
   hideOnClick: false,
 });
 
+// Define routes for the application. If header title is variable based on a route parameter (e.g. :filter, :id),
+// use 'titleFrom' to specify the route param to use for the title. If a suffix is needed (e.g. ' Tech Tree' or ' Recipe'), use 'titleSuffix'.
 const routes = [
   { path: '/', component: () => import('./components/ObjectBrowser.vue') },
-  { path: '/not-found', component: () => import('./components/NotFound.vue') },
-  { path: '/filter/:filter*', component: () => import('./components/ObjectBrowser.vue') },
-  { path: '/letters', component: () => import('./components/RecipeForLetters.vue') },
-  { path: '/versions', component: () => import('./components/ChangeLog.vue') },
-  { path: '/versions/:id', component: () => import('./components/ChangeLog.vue') },
-  { path: '/biomes/:id', component: () => import('./components/BiomeInspector.vue') },
-  { path: '/:id/tech-tree', component: () => import('./components/TechTree.vue') },
-  { path: '/:id/recipe', component: () => import('./components/Recipe.vue') },
-  { path: '/:id', component: () => import('./components/ObjectInspector.vue'), props: true },
+  { path: '/not-found', component: () => import('./components/NotFound.vue'), meta: { title: 'Not Found' } },
+  { path: '/filter/:filter*', component: () => import('./components/ObjectBrowser.vue'), meta: { titleFrom: 'filter' } },
+  { path: '/letters', component: () => import('./components/RecipeForLetters.vue'), meta: { title: 'Letters' } },
+  { path: '/versions', component: () => import('./components/ChangeLog.vue'), meta: { title: 'Versions' } },
+  { path: '/versions/:id', component: () => import('./components/ChangeLog.vue'), meta: { titleFrom: 'version' } },
+  { path: '/biomes/:id', component: () => import('./components/BiomeInspector.vue'), meta: { titleFrom: 'biome' } },
+  { path: '/:id/tech-tree', component: () => import('./components/TechTree.vue'), meta: { titleFrom: 'object', titleSuffix: ' Tech Tree' } },
+  { path: '/:id/recipe', component: () => import('./components/Recipe.vue'), meta: { titleFrom: 'object', titleSuffix: ' Recipe' } },
+  { path: '/:id', component: () => import('./components/ObjectInspector.vue'), props: true, meta: { titleFrom: 'object' } },
   { path: '/:catchAll(.*)', redirect: '/not-found' }, // Catch-all route for 404
 ];
 


### PR DESCRIPTION
Targets #118.

| Route              | Header example                          |
| ------------------ | --------------------------------------- |
| `/` | `Crafting reference for Two Hours One Life \| twotech` |
| `/not-found`       | `Not Found \| twotech`                  |
| `/filter/:filter*` | `Clothing \| twotech`                   |
| `/letters`         | `Letters \| twotech`                    |
| `/versions`        | `Versions \| twotech`                   |
| `/versions/:id`    | `Version 20326 \| twotech`              |
| `/biomes/:id`      | `Grasslands \| twotech`                 |
| `/:id/tech-tree`   | `Stone Tech Tree \| twotech`            |
| `/:id/recipe`      | `Stone Recipe \| twotech`               |
| `/:id`             | `Stone \| twotech`                      |

---

Note (because I wasn't sure about leaving comments in App.vue): We use filterParamParts to make sure we get a shallow copy of the filter if it is an array, because GameObject.js's `findFilter()` function may change the array passed into it, and we don't want to change route.params.filter in `pageTitle()` code. We just want to get the right filter so we can use its name.